### PR TITLE
Minor fixes

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -64,8 +64,7 @@ for cluster in dev east west ; do
     # Setup a gateway on the remote cluster.
     kubectl --context="k3d-$cluster" create ns linkerd-multicluster
     linkerd --context="k3d-$cluster" cluster setup-remote \
-            --gateway-namespace=linkerd-multicluster \
-            --service-account-namespace=linkerd-multicluster \
+            --namespace=linkerd-multicluster \
             --incoming-port=4180 \
             --probe-port=4181 |
         kubectl --context="k3d-$cluster" apply -f -

--- a/link.sh
+++ b/link.sh
@@ -2,22 +2,6 @@
 
 export ORG_DOMAIN="${ORG_DOMAIN:-k3d.example.com}"
 
-for cluster in dev east west ; do
-    # Setup a gateway on the remote cluster.
-    kubectl --context="k3d-$cluster" create ns linkerd-multicluster
-    linkerd --context="k3d-$cluster" cluster setup-remote \
-            --gateway-namespace=linkerd-multicluster \
-            --service-account-namespace=linkerd-multicluster \
-            --incoming-port=4180 \
-            --probe-port=4181 |
-        kubectl --context="k3d-$cluster" apply -f -
-
-    linkerd --context="k3d-$cluster" install-service-mirror \
-            --namespace=linkerd-multicluster \
-            --log-level=debug |
-        kubectl --context="k3d-$cluster" apply -f -
-done
-
 # Generate credentials so the service-mirror
 #
 # Unfortunately, the credentials have the API server IP as addressed from


### PR DESCRIPTION
This Pr addresses two things. 

- brings the CLI args in sync with what is on the latest master in linkerd2
- removes the redundant installation of gateway and service mirror to all cluster in link.sh

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>