### PR TITLE
Simplify fetch credentials to use --server-address

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -65,11 +65,8 @@ for cluster in dev east west ; do
     kubectl --context="k3d-$cluster" annotate ns/linkerd-multicluster \
         config.linkerd.io/proxy-version='ver-prevent-loop.0'
 
-    # Setup a gateway to receive traffic from other clusters.
-    linkerd --context="k3d-$cluster" cluster setup-remote |
+    # Setup the multicluster components on the server
+    linkerd --context="k3d-$cluster" cluster install --log-level=debug |
         kubectl --context="k3d-$cluster" apply -f -
 
-    # Setup a service-mirror to discover services from other clusters.
-    linkerd --context="k3d-$cluster" install-service-mirror  --log-level=debug |
-        kubectl --context="k3d-$cluster" apply -f -
 done

--- a/create.sh
+++ b/create.sh
@@ -66,7 +66,7 @@ for cluster in dev east west ; do
         config.linkerd.io/proxy-version='ver-prevent-loop.0'
 
     # Setup the multicluster components on the server
-    linkerd --context="k3d-$cluster" cluster install --log-level=debug |
+    linkerd --context="k3d-$cluster" multicluster install --log-level=debug |
         kubectl --context="k3d-$cluster" apply -f -
 
 done

--- a/link.sh
+++ b/link.sh
@@ -11,14 +11,13 @@ fetch_credentials() {
     # Grab the LB IP of cluster's API server & replace it in the secret blob:
     lb_ip=$(kubectl --context="k3d-$cluster" get svc -n kube-system traefik \
         -o 'go-template={{ (index .status.loadBalancer.ingress 0).ip }}')
-    secret=$(linkerd --context="k3d-$cluster" cluster get-credentials \
+    server_address="https://${lb_ip}:6443"
+    
+    # shellcheck disable=SC2001  
+    echo "$(linkerd --context="k3d-$cluster" cluster link \
             --cluster-name="$cluster" \
-            --remote-cluster-domain="${cluster}.${ORG_DOMAIN}")
-    config=$(echo "$secret" |
-        sed -ne 's/^  kubeconfig: //p' | base64 -d |
-        sed -Ee "s|server: https://.*|server: https://${lb_ip}:6443|" | base64 -w0)
-    # shellcheck disable=SC2001
-    echo "$secret" | sed -e "s/  kubeconfig: .*/  kubeconfig: $config/"
+            --remote-cluster-domain="${cluster}.${ORG_DOMAIN}" \
+            --cluster-server="$server_address")"
 }
 
 # East & West get access to each other.

--- a/link.sh
+++ b/link.sh
@@ -14,7 +14,7 @@ fetch_credentials() {
     server_address="https://${lb_ip}:6443"
     
     # shellcheck disable=SC2001  
-    echo "$(linkerd --context="k3d-$cluster" cluster link \
+    echo "$(linkerd --context="k3d-$cluster" multicluster link \
             --cluster-name="$cluster" \
             --remote-cluster-domain="${cluster}.${ORG_DOMAIN}" \
             --cluster-server="$server_address")"


### PR DESCRIPTION
This PR introduces some changes to bring the script in line with that is happening in https://github.com/linkerd/linkerd2/pull/4466 The most prominent change is making use of --cluster-address flag on the `link` command instead of manually idssecting the base64 encoded credentials

I have also updated the clusters to have separate credentials instead of sharing the default ones, thereby exercising the `allow` command

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>